### PR TITLE
chore(📦 react): 🤖 fixed incorrect dep version of core package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,6 @@
   "version": "0.2.0",
   "peerDependencies": {
     "react": ">=18",
-    "@atomic-storage/core": "^0.4.0"
+    "@atomic-storage/core": "^0.3.4"
   }
 }


### PR DESCRIPTION
peer dependency on `@atomic-storage/core` was incorrectly set to
`^0.4.0`, now it has been set to `^0.3.4`